### PR TITLE
Refactor Go Sprintf statements using Comby

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -276,7 +276,7 @@ func BenchmarkQueryContext(b *testing.B) {
 	)
 	defer db.Close()
 	for _, p := range []int{1, 2, 3, 4} {
-		b.Run(fmt.Sprintf("%d", p), func(b *testing.B) {
+		b.Run(strconv.Itoa(p), func(b *testing.B) {
 			benchmarkQueryContext(b, db, p)
 		})
 	}
@@ -312,7 +312,7 @@ func BenchmarkExecContext(b *testing.B) {
 	)
 	defer db.Close()
 	for _, p := range []int{1, 2, 3, 4} {
-		b.Run(fmt.Sprintf("%d", p), func(b *testing.B) {
+		b.Run(strconv.Itoa(p), func(b *testing.B) {
 			benchmarkQueryContext(b, db, p)
 		})
 	}


### PR DESCRIPTION
This campaign refactors Go code by replacing `fmt.Sprintf("%d", number)` statements with the equivalent but clearer `strconv.Itoa(number)`.

It uses [Comby](https://comby.dev) to do the replacement and then runs `gofmt` over the repositories.

Here is the action definition:

```json
{
  "scopeQuery": "lang:go fmt.Sprintf(\"%d\", fork:yes -repo:sourcegraph-testing/go",
  "steps": [
    {
      "type": "docker", "image": "comby/comby",
      "args": [ "-in-place", "fmt.Sprintf(\"%d\", :[v])", "strconv.Itoa(:[v])", ".go", "-matcher", ".go", "-d", "/work", "-exclude-dir", ".,vendor" ]
    },
    { "type": "docker", "image": "golang:1.14-alpine", "args": ["sh", "-c", "cd /work && go fmt ./..."] }
  ]
}
```